### PR TITLE
Update the specfile (and related) to build for SLE12 & SLE15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MANPATH=/usr/share/man
 PREFIX=/usr
 NAME=susepubliccloudinfo
 dirs = bin lib man
-files = Makefile README.md LICENSE setup.py
+files = Makefile README.md LICENSE setup.py requirements.txt requirements-dev.txt
 
 .PHONY: clean tar install pep8 test coverage list_tests
 

--- a/python3-susepubliccloudinfo.spec
+++ b/python3-susepubliccloudinfo.spec
@@ -15,7 +15,6 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-
 %define upstream_name susepubliccloudinfo
 Name:           python3-susepubliccloudinfo
 Version:        1.1.0
@@ -39,6 +38,7 @@ Obsoletes:      python-susepubliccloudinfo < %{version}
 %description
 Query the SUSE Public Cloud Information Service REST API
 
+%if 0%{?suse_version} > 1320
 %package amazon
 Summary:        Generate Amazon specific information
 Group:          System/Management
@@ -49,6 +49,7 @@ Requires:       python3-lxml
 %description amazon
 Script that generates information for Amazon to automate image inclusion
 in the quick launcher and the Support matrix on the AWS web pages.
+%endif
 
 %prep
 %setup -q -n %{upstream_name}-%{version}
@@ -64,14 +65,18 @@ gzip %{buildroot}/%{_mandir}/man1/pint.1
 
 %files
 %defattr(-,root,root,-)
-%doc LICENSE
+%license LICENSE
 %{_mandir}/man1/*
 %dir %{python3_sitelib}/susepubliccloudinfoclient
 %{python3_sitelib}/*
 %{_bindir}/pint
 
+%if 0%{?suse_version} > 1320
 %files amazon
 %defattr(-,root,root,-)
 %{_bindir}/awscsvgen
+%else
+%exclude %{_bindir}/awscsvgen
+%endif
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         package_dir={
             '': 'lib',
         },
-        scripts=['bin/pint'],
+        scripts=['bin/pint', 'bin/awscsvgen'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',


### PR DESCRIPTION
Per discussion in IRC, we'll move SLE12 to the python3 version, but not include the -amazon subpackage (due to dependencies).

During the process, I found that the new setup.py doesn't include the AWS bin file, and `setup.py build` complained about missing both requirements files.

re: https://trello.com/c/KXt5oOZ9
test build: https://build.opensuse.org/package/show/home:bear454:branches:Cloud:Tools/python3-susepubliccloudinfo