### PR TITLE
Include package data in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
 include LICENSE
+include README.md
+include python3-susepubliccloudinfo.spec
+include requirements.txt
+include requirements-dev.txt
+include bin/awscsvgen
+
 recursive-include man *

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
         author='SUSE Public Cloud Team',
         author_email='public-cloud-dev@susecloud.net',
         version=src_version,
+        include_package_data=True,
         install_requires=requirements,
         extras_require={
             'dev': dev_requirements
@@ -66,7 +67,7 @@ if __name__ == '__main__':
         package_dir={
             '': 'lib',
         },
-        scripts=['bin/pint', 'bin/awscsvgen'],
+        scripts=['bin/pint'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',


### PR DESCRIPTION
Update MANIFEST with relevelent files including awscsvgen binary.

@bear454 The include_package_data flag ensures what's in the MANIFEST file is included in the sdist. I've updated the file list to include the binary. So it's not installed by default but is included in the tarball.