### PR TITLE
Remove python 3.4 from Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"


### PR DESCRIPTION
Not all packages in dependency tree support 3.4.