### PR TITLE
Pint CLI should provide a message when no regions are available (CSE-79)

### DIFF
--- a/lib/susepubliccloudinfoclient/infoserverrequests.py
+++ b/lib/susepubliccloudinfoclient/infoserverrequests.py
@@ -262,6 +262,9 @@ def __parse_server_response_data(server_response_data, info_type):
 
 
 def __reformat(items, info_type, result_format):
+    if not items:
+        no_info_msg = "No information available. Please check your filter"
+        return no_info_msg
     if result_format == 'json':
         return json.dumps(
             {info_type: items},
@@ -297,6 +300,11 @@ def __process(url, info_type, command_arg_filter, result_format):
     """
     server_response_data = __get_data(url)
     resultset = __parse_server_response_data(server_response_data, info_type)
+    if info_type == 'regions':
+        if not resultset:
+            no_region_msg = "No region information available. Images have " \
+                            "the same identifier in all regions"
+            return no_region_msg
     if command_arg_filter:
         filters = __parse_command_arg_filter(command_arg_filter)
         resultset = __apply_filters(resultset, filters)

--- a/test/unit/test_no_region_info.py
+++ b/test/unit/test_no_region_info.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of susePublicCloudInfoClient
+#
+# susePublicCloudInfoClient is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# susePublicCloudInfoClient is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with susePublicCloudInfoClient. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+import lib.susepubliccloudinfoclient.infoserverrequests as ifsrequest
+from nose.tools import assert_equals
+
+
+def test_global_images_no_regions():
+    """Returns a no regions info message for global images"""
+    info_msg = "No region information available. Images have the same " \
+               "identifier in all regions"
+    result = ifsrequest.get_regions_data('oracle', None, 'json', 'all', None)
+    assert_equals(result, info_msg)


### PR DESCRIPTION
When the user queries for regions and the service returns an empty result, the CLI should provide the user with a plain text message indicating that there are no regions for the specified query... "No region information available."