### PR TITLE
Switch the package build a specified Python interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tar:  clean
 	rm -rf "$(NAME)-$(verSrc)"
 
 install:
-	python setup.py install --prefix="$(PREFIX)" --root="$(DESTDIR)"
+	python3 setup.py install --prefix="$(PREFIX)" --root="$(DESTDIR)"
 	install -d -m 755 "$(DESTDIR)"/"$(MANDIR)"/man1
 	install -m 644 man/man1/pint.1 "$(DESTDIR)"/"$(MANDIR)"/man1
 	gzip "$(DESTDIR)"/"$(MANDIR)"/man1/pint.1

--- a/lib/susepubliccloudinfoclient/version.py
+++ b/lib/susepubliccloudinfoclient/version.py
@@ -17,4 +17,4 @@
 # along with susePublicCloudInfoClient. If not, see
 # <http://www.gnu.org/licenses/>.
 #
-VERSION = '1.4.0'
+VERSION = '1.4.1'

--- a/python-susepubliccloudinfo.spec
+++ b/python-susepubliccloudinfo.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package python3-susepubliccloudinfo
+# spec file for package python-susepubliccloudinfo
 #
 # Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
@@ -15,27 +15,35 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version} >= 1600
+%define pythons %{primary_python}
+%else
+%{?sle15_python_module_pythons}
+%endif
+%global _sitelibdir %{%{pythons}_sitelib}
 
 %define upstream_name susepubliccloudinfo
-Name:           python3-susepubliccloudinfo
-Version:        1.4.0
+Name:           python-susepubliccloudinfo
+Version:        1.4.1
 Release:        0
 Summary:        Query SUSE Public Cloud Info Service
 License:        GPL-3.0-or-later
 Group:          System/Management
 Url:            https://github.com/SUSE-Enceladus/public-cloud-info-client
 Source0:        %{upstream_name}-%{version}.tar.bz2
-Requires:       python3
-Requires:       python3-docopt
-Requires:       python3-lxml
-Requires:       python3-requests
-BuildRequires:  python3-setuptools
+Requires:       python
+Requires:       python-docopt
+Requires:       python-lxml
+Requires:       python-requests
+BuildRequires:  %{pythons}-pip
+BuildRequires:  %{pythons}-setuptools
+BuildRequires:  %{pythons}-wheel
+BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
-Provides:       python-susepubliccloudinfo = %{version}
-Obsoletes:      python-susepubliccloudinfo < %{version}
+Obsoletes:      python3-susepubliccloudinfo < %{version}
 
 %description
 Query the SUSE Public Cloud Information Service REST API
@@ -44,20 +52,20 @@ Query the SUSE Public Cloud Information Service REST API
 %setup -q -n %{upstream_name}-%{version}
 
 %build
-python3 setup.py build
+%pyproject_wheel
 
 %install
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%pyproject_install
 install -d -m 755 %{buildroot}/%{_mandir}/man1
 install -m 644 man/man1/pint.1 %{buildroot}/%{_mandir}/man1
-gzip %{buildroot}/%{_mandir}/man1/pint.1
+%fdupes %{buildroot}%{$python_sitelib}
 
 %files
 %defattr(-,root,root,-)
 %license LICENSE
-%{_mandir}/man1/*
-%dir %{python3_sitelib}/susepubliccloudinfoclient
-%{python3_sitelib}/*
 %{_bindir}/pint
+%{_mandir}/man1/*
+%dir %{_sitelibdir}/susepubliccloudinfoclient
+%{_sitelibdir}/*
 
 %changelog


### PR DESCRIPTION
In openSUSE Factory we are working to eliminate all python3- packages. For SLE we can switch over to a Python 3.11 build starting with 15 SP4. If we need updates in code bases prior to 15 SP4 we will address those as package patches. For distributions >16 we use the define primary Python.

While the package also provides a library we do not want to support builds with multiple interpreters. Code that uses this package as library will have build with the specific interpreter for the distribution. The reason for this is that we do not want to change our image build setup every time the distribution changes the Python interpreter. A universal build setup produces python$PYVERSION-$NAME binary packages and we do not want to chase this in our image build setups.